### PR TITLE
Make foot force sensor reading calibrated with real robot

### DIFF
--- a/go2_simulation/bullet_wrapper.py
+++ b/go2_simulation/bullet_wrapper.py
@@ -142,6 +142,6 @@ class BulletWrapper(AbstractSimulatorWrapper):
             for id in self.env_ids:
                 contact_points += pybullet.getClosestPoints(self.robot, id, 0.005, joint_idx)
             if len(contact_points) > 0:  # If contact
-                f_current[i] = 100  # arbitrary value for now
+                f_current[i] = 39.4  # roughly 1/4 of the robot mass (0th order approx)
 
         return q_current, v_current, a_current, f_current

--- a/go2_simulation/simple_wrapper.py
+++ b/go2_simulation/simple_wrapper.py
@@ -86,10 +86,10 @@ class SimpleSimulator:
             cp = self.simulator.geom_model.collisionPairs[cp_id]
             first = self.simulator.geom_model.geometryObjects[cp.first].name
             if first in self.foot_names:
-                self.f_feet[self.foot_names.index(first)] = 1
+                self.f_feet[self.foot_names.index(first)] = 39.4  # roughly 1/4 of the robot mass (0th order approx)
             second = self.simulator.geom_model.geometryObjects[cp.second].name
             if second in self.foot_names:
-                self.f_feet[self.foot_names.index(second)] = 1
+                self.f_feet[self.foot_names.index(second)] = 39.4  # roughly 1/4 of the robot mass (0th order approx)
 
         return self.q, self.v, self.a, self.f_feet
 

--- a/go2_simulation/simulation_node.py
+++ b/go2_simulation/simulation_node.py
@@ -83,7 +83,8 @@ class Go2Simulation(Node):
             low_msg.motor_state[joint_idx].dq = self.v_current[6 + joint_idx]
 
         # Contact sensors reading
-        low_msg.foot_force = self.f_current.astype(np.int32).tolist()
+        ## See https://github.com/inria-paris-robotics-lab/go2_simulation/issues/6
+        low_msg.foot_force = (14.2 * np.ones(4) + 0.562 * self.f_current).astype(np.int32).tolist()
 
         # Format IMU
         quat_xyzw = self.q_current[3:7].tolist()


### PR DESCRIPTION
Following https://github.com/inria-paris-robotics-lab/go2_simulation/issues/6

PR to calibrated foot sensor value with real robot.

Noe: both SimpleWrapper and BulletWrapper ouptut an arbitrary foot force when the feet are in contacts (as they are not yet able to compute the actual force). However, the Simulation node does translate this force into the proper calibrated value.
So I changed both wrapper to output a force of 1/4th of the robot mass (39.4 N) when foot is in contact